### PR TITLE
change sitl_run to load typhoon_h480

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -43,8 +43,8 @@ fi
 
 if [ "$model" == "" ] || [ "$model" == "none" ]
 then
-	echo "empty model, setting sd5 as default"
-	model="sd5"
+	echo "empty model, setting typhoon_h480 (sicdrone) as default"
+	model="typhoon_h480"
 fi
 
 # check replay mode


### PR DESCRIPTION
Changed the Tools/sitl_run.sh file to load typhoon_h480 instead of sd5. That way we load the sicdrone model instead of the iris model.

Gazebo may crash the first time, but should run the second.

Be careful with this merge, since the Firmware repo is separate from the Tools/sitl_gazebo repo, even though merges need to be done in both repos.